### PR TITLE
Cmake changes for subdir builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ persists.")
 # Get the current working branch
 execute_process(
   COMMAND git rev-parse --abbrev-ref HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_BRANCH
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -203,7 +203,7 @@ execute_process(
 # Get the current working tag
 execute_process(
   COMMAND git describe --abbrev=0 --tags
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_TAG
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -211,7 +211,7 @@ execute_process(
 # Get the latest abbreviated commit hash of the working branch
 execute_process(
   COMMAND git log -1 --format=%h
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE GIT_COMMIT_HASH
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -913,8 +913,8 @@ if (RCR_FOUND)
 SET(extraincludes "-I${RCR_INCLUDE_DIR}")
 endif (RCR_FOUND)
 SET(requirements "")
-CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/pkgconfig/apex.pc.in
-               ${CMAKE_BINARY_DIR}/pkgconfig/apex.pc @ONLY)
+CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/pkgconfig/apex.pc.in
+	${PROJECT_BINARY_DIR}/pkgconfig/apex.pc @ONLY)
 INSTALL_FILES(/lib/pkgconfig FILES pkgconfig/apex.pc)
 
 if (APEX_USE_WEAK_SYMBOLS)

--- a/src/scripts/CMakeLists.txt
+++ b/src/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
-CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/src/scripts/apex_exec
-    ${CMAKE_BINARY_DIR}/src/scripts/apex_exec @ONLY)
+CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/src/scripts/apex_exec
+	${PROJECT_BINARY_DIR}/src/scripts/apex_exec @ONLY)
 #INSTALL_FILES(bin FILES ${CMAKE_BINARY_DIR}/src/scripts/apex_exec)
 
 
@@ -9,7 +9,7 @@ if (BUILD_STATIC_EXECUTABLES)
             GROUP_EXECUTE GROUP_READ
             WORLD_EXECUTE WORLD_READ)
 else()
-    INSTALL(FILES ${CMAKE_BINARY_DIR}/src/scripts/apex_exec apex_pthread_exec consolidate.py task_scatterplot.py counter_scatterplot.py DESTINATION bin
+	INSTALL(FILES ${PROJECT_BINARY_DIR}/src/scripts/apex_exec apex_pthread_exec consolidate.py task_scatterplot.py counter_scatterplot.py DESTINATION bin
             PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
             GROUP_EXECUTE GROUP_READ
             WORLD_EXECUTE WORLD_READ)


### PR DESCRIPTION
So, one common use case is to add a library as a subdirectory. These CMake changes allow APEX to work in this form. I'd test whether your builds work and let me know if anything is shaky, but this enables the case where APEX is a subdirectory of a tools repo