### PR TITLE
Rename use of `hpx::util::annotated_function` to `hpx::annotated_function`

### DIFF
--- a/src/apex/profiler_listener.cpp
+++ b/src/apex/profiler_listener.cpp
@@ -1782,7 +1782,7 @@ void apex_schedule_process_profiles() {
         if(!consumer_task_running.test_and_set(memory_order_acq_rel)) {
             try {
                 hpx::apply(
-                    hpx::util::annotated_function(
+                    hpx::annotated_function(
                         &profiler_listener::process_profiles_wrapper,
                         "apex::profiler_listener::process_profiles"));
             } catch(...) {


### PR DESCRIPTION
We're moving `hpx::util::annotated_function` to the top-level namespace in https://github.com/STEllAR-GROUP/hpx/pull/5691. This change avoids the deprecation warning triggered by that change.